### PR TITLE
Update links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is the working area for the Individual internet-draft, "Using MUD in CoAP".
 
 * [Editor's Copy](http://namib-project.github.io/draft-coap-mud/#go.draft-jimenez-t2trg-mud-coap.html)
-* [Individual Submission Draft](https://tools.ietf.org/html/draft-jimenez-t2trg-mud-coap-00)
+<!-- * [Individual Submission Draft](https://tools.ietf.org/html/draft-romann-mud-constrained-00) -->
 
 ## Building the Draft
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the working area for the Individual internet-draft, "Using MUD in CoAP".
 
-* [Editor's Copy](http://namib.me/draft-coap-mud/#go.draft-jimenez-t2trg-mud-coap.html)
+* [Editor's Copy](http://namib-project.github.io/draft-coap-mud/#go.draft-jimenez-t2trg-mud-coap.html)
 * [Individual Submission Draft](https://tools.ietf.org/html/draft-jimenez-t2trg-mud-coap-00)
 
 ## Building the Draft


### PR DESCRIPTION
Since our ownership of `namib.me` has expired (which is a bit unfortunate), this PR updates the Editor's Draft link to point to `namib-project.github.io` instead.

I also updated the "Individual Submission Draft" link to point to the potential place where our document would be available once we submit it (at some point). However, since no submission is available yet, I just commented out the updated line.